### PR TITLE
refactor: keep net10 and tighten jwt setup

### DIFF
--- a/Backend/Agrohub.Auth/Options/JwtOptions.cs
+++ b/Backend/Agrohub.Auth/Options/JwtOptions.cs
@@ -1,0 +1,9 @@
+namespace Agrohub.Auth.Options;
+
+public sealed class JwtOptions
+{
+    public required string Issuer { get; init; }
+    public required string Audience { get; init; }
+    public required string Key { get; init; }
+    public int AccessMinutes { get; init; } = 10;
+}

--- a/Backend/Agrohub.Auth/Program.cs
+++ b/Backend/Agrohub.Auth/Program.cs
@@ -1,7 +1,8 @@
-﻿using Agrohub.Auth.Behaviors;
+using Agrohub.Auth.Behaviors;
 using Agrohub.Auth.Data.Interceptors;
 using Agrohub.Auth.Interfaces;
 using Agrohub.Auth.Implementations;
+using Agrohub.Auth.Options;
 using Carter;
 using FluentValidation;
 using MediatR;
@@ -42,7 +43,9 @@ builder.Services.AddCors(o => o.AddPolicy("spa", p =>
 
 // --- JWT AuthN/AuthZ
 var jwt = builder.Configuration.GetSection("Jwt");
-var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwt["Key"]!));
+builder.Services.Configure<JwtOptions>(jwt);
+var jwtOptions = jwt.Get<JwtOptions>()!;
+var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtOptions.Key));
 
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(opts =>
@@ -50,9 +53,9 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
         opts.TokenValidationParameters = new TokenValidationParameters
         {
             ValidateIssuer = true,
-            ValidIssuer = jwt["Issuer"],
+            ValidIssuer = jwtOptions.Issuer,
             ValidateAudience = true,
-            ValidAudience = jwt["Audience"],
+            ValidAudience = jwtOptions.Audience,
             ValidateIssuerSigningKey = true,
             IssuerSigningKey = key,
             ValidateLifetime = true,

--- a/Backend/Agrohub.Auth/appsettings.json
+++ b/Backend/Agrohub.Auth/appsettings.json
@@ -8,7 +8,8 @@
   "Jwt": {
     "Issuer": "https://localhost:5001",
     "Audience": "agrohub.spa",
-    "Key": "super-secret-at-least-32-bytes-key"
+    "Key": "super-secret-at-least-32-bytes-key",
+    "AccessMinutes": 10
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
## Summary
- restore target framework to net10.0
- configure JWT authentication using typed options
- require JWT option fields via `required`

## Testing
- `dotnet build Backend/Agrohub.Auth/Agrohub.Auth.csproj` *(fails: .NET 10.0 not supported by installed SDK)*

------
https://chatgpt.com/codex/tasks/task_e_689724771de4832fb845b8cf6ad1190f